### PR TITLE
Cadastro de Notas fiscais corrigido

### DIFF
--- a/src/main/java/com/example/salesflow/controller/dto/cadastro/NotaFiscalCadastroDTO.java
+++ b/src/main/java/com/example/salesflow/controller/dto/cadastro/NotaFiscalCadastroDTO.java
@@ -1,8 +1,8 @@
 package com.example.salesflow.controller.dto.cadastro;
 
+import java.math.BigDecimal;
 import java.util.List;
 
-import com.example.salesflow.model.TransacaoType;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record NotaFiscalCadastroDTO(
                             @NotNull(message="Campo obrigatório")
-                            TransacaoType tipoTransacao,
+                            String tipoTransacao,
                             String clienteCpf,
                             String fornecedorCnpj,
                             @NotEmpty(message="A nota fiscal deve conter ao menos um item/produto")
@@ -21,7 +21,7 @@ public record NotaFiscalCadastroDTO(
 
     @AssertTrue(message = "CPF inválido")
     public boolean isCpfValidoSeVenda() {
-        if (tipoTransacao == TransacaoType.VENDA) {
+        if (tipoTransacao == "VENDA") {
             return clienteCpf != null && new org.hibernate.validator.internal.constraintvalidators.hv.br.CPFValidator().isValid(clienteCpf, null);
         }
         return true;
@@ -29,7 +29,7 @@ public record NotaFiscalCadastroDTO(
 
     @AssertTrue(message = "CNPJ inválido")
     public boolean isCnpjValidoSeCompra() {
-        if (tipoTransacao == TransacaoType.COMPRA) {
+        if (tipoTransacao == "COMPRA") {
             return fornecedorCnpj != null && new org.hibernate.validator.internal.constraintvalidators.hv.br.CNPJValidator().isValid(fornecedorCnpj, null);
         }
         return true;

--- a/src/main/java/com/example/salesflow/controller/dto/pesquisa/NotaFiscalPesquisaDTO.java
+++ b/src/main/java/com/example/salesflow/controller/dto/pesquisa/NotaFiscalPesquisaDTO.java
@@ -10,7 +10,7 @@ import com.example.salesflow.model.TransacaoType;
 public record NotaFiscalPesquisaDTO(
     Long numNota,
     BigDecimal valorTotal,
-    TransacaoType tipoTransacao,
+    String tipoTransacao,
     ClienteSummaryDTO cliente,
     FornecedorSummaryDTO fornecedor,
     LocalDateTime data)   {

--- a/src/main/java/com/example/salesflow/controller/viewcontrollers/NotaFiscalController.java
+++ b/src/main/java/com/example/salesflow/controller/viewcontrollers/NotaFiscalController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
@@ -19,7 +18,6 @@ import com.example.salesflow.controller.dto.cadastro.NotaFiscalCadastroDTO;
 import com.example.salesflow.controller.dto.pesquisa.NotaFiscalPesquisaDTO;
 import com.example.salesflow.controller.mappers.NotaFiscalMapper;
 import com.example.salesflow.model.NotaFiscal;
-import com.example.salesflow.model.TransacaoType;
 import com.example.salesflow.service.NotasService;
 
 import jakarta.validation.Valid;
@@ -38,49 +36,29 @@ public class NotaFiscalController {
         return "pages/nota-cadastro";
     }
 
-    @RequestMapping(path = "/cadastrar", method = RequestMethod.POST)
+    @PostMapping("/cadastrar")
     public String cadastrar(@ModelAttribute @Valid NotaFiscalCadastroDTO dto,
                                     BindingResult result, Model model,
                                     RedirectAttributes redirectAttributes){
-    
+        if(result.hasErrors()){
+            model.addAttribute("erro", result.getAllErrors());
+            return "pages/nota-cadastro";
+        }
         try {
-            // notaFiscalService.salvar(dto);
-            return "redirect:/";
+            notaFiscalService.salvar(dto);
+            model.addAttribute("mensagem", "Nota cadastrada com sucesso");
+            return "pages/nota-cadastro";
         } catch (Exception e) {
-            e.printStackTrace();
-            return "redirect:/";
+            System.err.print(e.getMessage());
+            model.addAttribute("erro", "Erro no cadastro da nota");
+            return "pages/nota-cadastro";
         }
     }
-
-    // @GetMapping("{num_nota}")
-    // public NotaFiscal obterPorId(@PathVariable("num_nota") Long id){
-    //     return notaFiscalService.buscaPorId(id);
-    // }
-
-    // @GetMapping("/por_cpf")
-    // public List<NotaFiscalPesquisaDTO> buscaNotaPorCpf(@RequestParam String cpf) {
-    //     List<NotaFiscal> notas = notaFiscalService.buscaPorCpf(cpf);
-
-    //     return notas
-    //         .stream()
-    //         .map(nota -> mapper.toDTO(nota))
-    //         .collect(Collectors.toList());
-    // } 
-
-    // @GetMapping("/por_cnpj")
-    // public List<NotaFiscalPesquisaDTO> buscaNotaPorCnpj(@RequestParam String cnpj){
-    //     List<NotaFiscal> notas = notaFiscalService.buscaPorCnpj(cnpj);
-
-    //     return notas
-    //         .stream()
-    //         .map(nota -> mapper.toDTO(nota))
-    //         .collect(Collectors.toList());
-    // }
 
     @GetMapping
     public String pesquisa(Model model,
                 @RequestParam(value = "numNota", required = false) Long numNota,
-                @RequestParam(value = "tipoTransacao", required = false) TransacaoType tipoTransacao,
+                @RequestParam(value = "tipoTransacao", required = false) String tipoTransacao,
                 @RequestParam(value = "clienteCpf", required = false) String clienteCpf,
                 @RequestParam(value = "fornecedorCnpj", required = false) String fornecedorCnpj,
                 @RequestParam(value = "dataInicio", required = false) LocalDate dataInicio,
@@ -88,26 +66,22 @@ public class NotaFiscalController {
                 @RequestParam(value = "pagina", defaultValue = "0") Integer pagina,
                 @RequestParam(value = "tamanho-pagina", defaultValue = "10") Integer tamanhoPagina){
         
-        
-        try{
-            Page<NotaFiscal> paginaResultado = notaFiscalService.pesquisa(numNota, tipoTransacao, 
-                        clienteCpf, fornecedorCnpj, dataInicio, dataFinal, pagina, tamanhoPagina);
-                        
-                        model.addAttribute("titulo", "Notas");
-                        model.addAttribute("numNota", numNota);
-                        model.addAttribute("tipoTransacao", tipoTransacao);
-                        model.addAttribute("clienteCpf", clienteCpf);
-                        model.addAttribute("fornecedorCnpj", fornecedorCnpj);
-                        model.addAttribute("dataInicio", dataInicio);
-                        model.addAttribute("dataFinal", dataFinal);
-            List<NotaFiscalPesquisaDTO> resultado = paginaResultado.getContent()
-                        .stream()
-                        .map(mapper::toDTO)
-                        .toList();
-            model.addAttribute("notas", resultado);
-        }catch(Exception e){
-            e.printStackTrace();
-        }
+    
+        Page<NotaFiscal> paginaResultado = notaFiscalService.pesquisa(numNota, tipoTransacao, 
+                    clienteCpf, fornecedorCnpj, dataInicio, dataFinal, pagina, tamanhoPagina);
+                    
+                    model.addAttribute("titulo", "Notas");
+                    model.addAttribute("numNota", numNota);
+                    model.addAttribute("tipoTransacao", tipoTransacao);
+                    model.addAttribute("clienteCpf", clienteCpf);
+                    model.addAttribute("fornecedorCnpj", fornecedorCnpj);
+                    model.addAttribute("dataInicio", dataInicio);
+                    model.addAttribute("dataFinal", dataFinal);
+        List<NotaFiscalPesquisaDTO> resultado = paginaResultado.getContent()
+                    .stream()
+                    .map(mapper::toDTO)
+                    .toList();
+        model.addAttribute("notas", resultado);
 
         return "pages/lista-notas_fiscais";
     }

--- a/src/main/java/com/example/salesflow/model/NotaFiscal.java
+++ b/src/main/java/com/example/salesflow/model/NotaFiscal.java
@@ -36,8 +36,7 @@ public class NotaFiscal {
     private Long numNota;
 
     @Column
-    @Enumerated(EnumType.STRING)
-    private TransacaoType tipoTransacao;
+    private String tipoTransacao;
 
     @Column(name="valorTotal", precision=18, scale=2)
     private BigDecimal valorTotal;

--- a/src/main/java/com/example/salesflow/repository/NotaFiscalSpecs.java
+++ b/src/main/java/com/example/salesflow/repository/NotaFiscalSpecs.java
@@ -23,7 +23,7 @@ public class NotaFiscalSpecs {
         return (root, query, cb) -> cb.equal(root.get("numNota"), numNota);
     }
     
-    public static Specification<NotaFiscal> tipoTransacaoEqual(TransacaoType tipoTransacao){
+    public static Specification<NotaFiscal> tipoTransacaoEqual(String tipoTransacao){
         return (root, query, cb) -> cb.equal(root.get("tipoTransacao"), tipoTransacao);
     }
  

--- a/src/main/java/com/example/salesflow/repository/NotasRepository.java
+++ b/src/main/java/com/example/salesflow/repository/NotasRepository.java
@@ -28,7 +28,7 @@ public interface NotasRepository extends JpaRepository<NotaFiscal, Long>, JpaSpe
     @Query("SELECT SUM(nf.valorTotal) FROM NotaFiscal nf " +
            "WHERE nf.tipoTransacao = :tipoTransacao AND MONTH(nf.data) = :month AND YEAR(nf.data) = :year")
     Optional<BigDecimal> findTotalByTransacaoAndMonthAndYear(
-        @Param("tipoTransacao") TransacaoType tipoTransacao, 
+        @Param("tipoTransacao") String tipoTransacao, 
         @Param("month") int month, 
         @Param("year") int year);
 
@@ -38,7 +38,7 @@ public interface NotasRepository extends JpaRepository<NotaFiscal, Long>, JpaSpe
             "GROUP BY i.produto.nome "+
             "ORDER BY SUM(i.quantidade) DESC")
     List<ProdutoVendidoDTO> findTop10ProdutosMaisVendidos(
-        @Param("tipoTransacao") TransacaoType tipoTransacao,
+        @Param("tipoTransacao") String tipoTransacao,
         @Param("dataInicial") LocalDate dataInicial,
         @Param("dataFinal") LocalDate dataFinal);
 

--- a/src/main/resources/static/css/pages/home.css
+++ b/src/main/resources/static/css/pages/home.css
@@ -48,6 +48,8 @@
     display: flex; /* Habilita o Flexbox */
     gap: 10px; /* Adiciona um espaço entre os itens */
     align-items: center; /* Alinha os itens verticalmente ao centro */
+    flex-direction: row;
+    justify-content: space-between;
 }
 
 

--- a/src/main/resources/templates/pages/lista-notas_fiscais.html
+++ b/src/main/resources/templates/pages/lista-notas_fiscais.html
@@ -49,9 +49,9 @@
                             <td th:text="${nota.numNota}">Número da nota</td>
                             <td th:text="${nota.tipoTransacao}">Tipo de transação</td>
                             <td th:text="${nota.valorTotal}">Valor total</td>
-                            <td th:text="${nota.tipoTransacao == T(com.example.salesflow.model.TransacaoType).VENDA ? 
+                            <td th:text="${nota.tipoTransacao == 'VENDA' ? 
                                       (nota.cliente!= null ? nota.cliente.cpf : 'Sem informação') : 'Sem informação'}">CPF</td>
-                            <td th:text="${nota.tipoTransacao == T(com.example.salesflow.model.TransacaoType).COMPRA ? 
+                            <td th:text="${nota.tipoTransacao == 'COMPRA' ? 
                                       (nota.fornecedor != null ? nota.fornecedor.cnpj : 'Sem informação') : 'Sem informação'}">CNPJ</td>
                             <td th:text="${nota.data != null ? #temporals.format(nota.data, 'dd/MM/yyyy HH:mm') : 'Sem data'}">Data de emissão</td>                            
                         </tr>

--- a/src/main/resources/templates/pages/nota-cadastro.html
+++ b/src/main/resources/templates/pages/nota-cadastro.html
@@ -13,12 +13,16 @@
             <div class="container-cadastro">
                 <form id="notaFiscalForm" method="post" th:action="@{/notas_fiscais/cadastrar}">
                     <div class="coluna-esquerda">
-                        <label for="tipoTransacao">Tipo de Transação:</label>
-                        <select name="tipoTransacao" id="tipoTransacao" th:value="${tipoTransacao}" onchange="mostrarCampos()">
-                            <option value="">Selecione o Tipo</option>
-                            <option value="COMPRA">Compra</option>
-                            <option value="VENDA">Venda</option>
-                        </select>
+
+                        <label for="tipoTransacao">Selecione o Tipo:</label>
+                        <input type="text" list="opcoesTransacao" name="tipoTransacao" id="tipoTransacao"
+                            th:value="${tipoTransacao}" 
+                            onchange="mostrarCampos()">
+                            
+                        <datalist id="opcoesTransacao">
+                            <option value="COMPRA"></option>
+                            <option value="VENDA"></option>
+                        </datalist>
 
                         <div class="cpfDiv">
                             <input type="text" class="mask-cpf"  name="clienteCpf" placeholder="CPF do cliente" />
@@ -27,14 +31,7 @@
                         <div class="cnpjDiv">
                             <input type="text" class="mask-cnpj" name="fornecedorCnpj" placeholder="CNPJ do fornecedor" />
                         </div>
-
-                        <label for="valorTotal">Valor Total:</label>
-                        <input type="number" step="0.01" name="valorTotal" placeholder="Valor total da nota" required />
-
-                        <label for="desconto">Desconto:</label>
-                        <input type="number" step="0.01" name="desconto" placeholder="Desconto (se houver)" />
-                        </div>
-
+                        
                         <div class="coluna-direita">
                         <div class="cadastro-item">
                             <label for="produtoId">ID do Produto:</label>
@@ -62,8 +59,9 @@
                             </thead>
                             <tbody></tbody>
                             </table>
-                        </div>
+                        </div> 
                     </div>
+                    
 
                     <div class="botao-submit">
                     <button type="submit">Cadastrar Nota Fiscal</button>
@@ -73,9 +71,5 @@
                 <p th:if="${mensagem}" th:text="${mensagem}"></p>
                 <p th:if="${erro}" th:text="${erro}" style="color:red;"></p>
         </main>
-        <script src="https://unpkg.com/imask"></script>
-        <script th:src="@{/js/masks.js}"></script>
-        <script th:src="@{/js/filtro-notas.js}"></script>
-        <script th:src="@{/js/cadastro-notas.js}"></script>
     </body>
 </html>


### PR DESCRIPTION
O erro parecia estar no enum para o cadastro do tipo de nota. Agora é com String CapsLock "VENDA" ou "COMPRA" e a verificação para CNPJ ou CPF é feita com base nisso.

Os itens da nota são persistidos automaticamente após serem adicionados à nota com addItem() por sua relação com NotaFiscal estar marcada com:
@OneToMany(mappedBy = "notaFiscal", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.Lazy)